### PR TITLE
Continuous write operation for websocket messages.

### DIFF
--- a/examples/networking/networking.c
+++ b/examples/networking/networking.c
@@ -1256,6 +1256,11 @@ static int LwsWebsocketCallback( struct lws * pWsi,
                         LogError( ( "Failed to remove element from the ring buffer!" ) );
                         ret = 1;
                     }
+                    else
+                    {
+                        /* Check if there is any data remain in ringbuffer at next iteration. */
+                        lws_callback_on_writable( pWsi );
+                    }
                 }
                 else
                 {
@@ -1745,7 +1750,6 @@ NetworkingResult_t Networking_WebsocketSend( NetworkingWebsocketContext_t * pWeb
         /* This will cause a LWS_CALLBACK_EVENT_WAIT_CANCELLED in the lws
          * service thread context. */
         lws_cancel_service( pWebsocketCtx->pLwsContext );
-
     }
 
     return ret;


### PR DESCRIPTION
*Issue #, if available:*
When there are multiple messages stored in the ring buffer, the websocket send stop sending after completing the first message.

*Description of changes:*
By applying this change, we'll check the ringbuffer by the second iteration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
