### PR TITLE
libusrsctp.cmake: fix dependency handling when building with yocto

### DIFF
--- a/CMake/libusrsctp.cmake
+++ b/CMake/libusrsctp.cmake
@@ -8,6 +8,7 @@ endif()
 
 # Custom target to build the usrsctp library
 add_custom_target(usrsctp-build ALL
+    BYPRODUCTS ${LIBUSRSCTP_BUILD_DIR}/lib/libusrsctp.a
     COMMAND ${CMAKE_COMMAND} -S ${LIBUSRSCTP_SOURCE_DIR} -B ${LIBUSRSCTP_BUILD_DIR}
             -DCMAKE_INSTALL_PREFIX=${LIBUSRSCTP_BUILD_DIR}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
Without this modification usrsctp lib was not build as a dependency.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
