### PR TITLE
Reorder JoinStorageSession Call Sequence to maintain uniformity

### DIFF
--- a/examples/metric/metric.c
+++ b/examples/metric/metric.c
@@ -41,9 +41,6 @@ static const char * ConvertEventToString( MetricEvent_t event )
         case METRIC_EVENT_SIGNALING_GET_CREDENTIALS:
             pRet = "Get Authentication Temporary Credentials";
             break;
-        case METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION:
-            pRet = "Join Storage Session";
-            break;
         case METRIC_EVENT_ICE_GATHER_HOST_CANDIDATES:
             pRet = "Gather ICE Host Candidate";
             break;
@@ -52,6 +49,9 @@ static const char * ConvertEventToString( MetricEvent_t event )
             break;
         case METRIC_EVENT_ICE_GATHER_RELAY_CANDIDATES:
             pRet = "Gather ICE Relay Candidate";
+            break;
+        case METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION:
+            pRet = "Join Storage Session";
             break;
         case METRIC_EVENT_ICE_FIND_P2P_CONNECTION:
             pRet = "Find Peer-To-Peer Connection";

--- a/examples/signaling_controller/signaling_controller.c
+++ b/examples/signaling_controller/signaling_controller.c
@@ -867,15 +867,6 @@ static SignalingControllerResult_t ConnectToSignalingService( SignalingControlle
         Metric_EndEvent( METRIC_EVENT_SIGNALING_GET_ENDPOINTS );
     }
 
-    /* Join the storage session, if enabled. */
-    if( ( ret == SIGNALING_CONTROLLER_RESULT_OK ) &&
-        ( pConnectInfo->enableStorageSession != 0 ) )
-    {
-        Metric_StartEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
-        ret = JoinStorageSession( pCtx );
-        Metric_EndEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
-    }
-
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )
     {
         Metric_StartEvent( METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST );
@@ -888,6 +879,15 @@ static SignalingControllerResult_t ConnectToSignalingService( SignalingControlle
         Metric_StartEvent( METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER );
         ret = ConnectToWssEndpoint( pCtx );
         Metric_EndEvent( METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER );
+    }
+
+    /* Join the storage session, if enabled. */
+    if( ( ret == SIGNALING_CONTROLLER_RESULT_OK ) &&
+        ( pConnectInfo->enableStorageSession != 0 ) )
+    {
+        Metric_StartEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
+        ret = JoinStorageSession( pCtx );
+        Metric_EndEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
     }
 
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )


### PR DESCRIPTION
### Description
This PR modifies the sequence of JoinStorageSession functionality to uniformize media ingestion to the cloud in both applications.

Changes:
1. Moved JoinStorageSession call to execute immediately after `ConnectToWssEndpoint`
2. Previous implementation had JoinStorageSession just after `GetSignalingChannelEndpoints`

### Test Steps
```
//set the JOIN_STORAGE_SESSION macro as 1

// Build the application
cmake -S . -B build
make -C build

// Run the application
./build/WebRTCLinuxApplicationMaster
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
