### PR TITLE
Reset fileIndex with no connected peers

### DIFF
--- a/examples/app_media_source/app_media_source.c
+++ b/examples/app_media_source/app_media_source.c
@@ -45,7 +45,6 @@ static void * VideoTx_Task( void * pParameter )
     #ifndef ENABLE_STREAMING_LOOPBACK
         char filePath[ MAX_PATH_LEN + 1 ];
         FILE * fp = NULL;
-        int32_t fileIndex = 0;
         size_t frameLength;
         size_t allocatedBufferLength = 0;
     #endif /* ENABLE_STREAMING_LOOPBACK */
@@ -64,8 +63,8 @@ static void * VideoTx_Task( void * pParameter )
             #ifndef ENABLE_STREAMING_LOOPBACK
                 if( pVideoContext->numReadyPeer != 0 )
                 {
-                    fileIndex = fileIndex % NUMBER_OF_H264_FRAME_SAMPLE_FILES + 1;
-                    snprintf( filePath, MAX_PATH_LEN, "./examples/app_media_source/samples/h264SampleFrames/frame-%04d.h264", fileIndex );
+                    pVideoContext->fileIndex = pVideoContext->fileIndex % NUMBER_OF_H264_FRAME_SAMPLE_FILES + 1;
+                    snprintf( filePath, MAX_PATH_LEN, "./examples/app_media_source/samples/h264SampleFrames/frame-%04d.h264", pVideoContext->fileIndex );
 
                     fp = fopen( filePath, "rb" );
 
@@ -123,7 +122,6 @@ static void * AudioTx_Task( void * pParameter )
     #ifndef ENABLE_STREAMING_LOOPBACK
         char filePath[ MAX_PATH_LEN + 1 ];
         FILE * fp = NULL;
-        int32_t fileIndex = 0;
         size_t frameLength;
         size_t allocatedBufferLength = 0;
     #endif /* ENABLE_STREAMING_LOOPBACK */
@@ -142,8 +140,8 @@ static void * AudioTx_Task( void * pParameter )
             #ifndef ENABLE_STREAMING_LOOPBACK
                 if( pAudioContext->numReadyPeer != 0 )
                 {
-                    fileIndex = fileIndex % NUMBER_OF_OPUS_FRAME_SAMPLE_FILES + 1;
-                    snprintf( filePath, MAX_PATH_LEN, "./examples/app_media_source/samples/opusSampleFrames/sample-%03d.opus", fileIndex );
+                    pAudioContext->fileIndex = pAudioContext->fileIndex % NUMBER_OF_OPUS_FRAME_SAMPLE_FILES + 1;
+                    snprintf( filePath, MAX_PATH_LEN, "./examples/app_media_source/samples/opusSampleFrames/sample-%03d.opus", pAudioContext->fileIndex );
 
                     fp = fopen( filePath, "rb" );
 
@@ -244,6 +242,10 @@ static int32_t OnPcEventRemotePeerClosed( AppMediaSourceContext_t * pMediaSource
             if( pMediaSource->numReadyPeer > 0U )
             {
                 pMediaSource->numReadyPeer--;
+                if( pMediaSource->numReadyPeer == 0 )
+                {
+                    pMediaSource->fileIndex = 0;
+                }
             }
 
             /* We have finished accessing the shared resource.  Release the mutex. */

--- a/examples/app_media_source/app_media_source.h
+++ b/examples/app_media_source/app_media_source.h
@@ -30,6 +30,7 @@ typedef struct AppMediaSourceContext
     MessageQueueHandler_t dataQueue;
     uint8_t numReadyPeer;
     TransceiverTrackKind_t trackKind;
+    int32_t fileIndex;
 
     AppMediaSourcesContext_t * pSourcesContext;
 } AppMediaSourceContext_t;


### PR DESCRIPTION
*Issue #, if available:*
In multiple session the fileIndex was not cleared hence the streaming was continuing from the current file index. And in case when new peers connects and the frame is not the key frame the decoding was not possible till a key frame is received which was leading to increased TTFF time. 

*Description of changes:*
Reset the fileIndex whenever the number of ready peers reaches zero. This ensure the next peer start receiveing the frames from the beginning, avoiding delay in video/audio decoding. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
