### PR TITLE
Remove taking session in NACK resend.

### DIFF
--- a/examples/peer_connection/peer_connection_srtcp.c
+++ b/examples/peer_connection/peer_connection_srtcp.c
@@ -61,7 +61,6 @@ static PeerConnectionResult_t ResendSrtpPacket( PeerConnectionSession_t * pSessi
     PeerConnectionResult_t ret = PEER_CONNECTION_RESULT_OK;
     PeerConnectionSrtpSender_t * pSrtpSender = NULL;
     uint8_t isSenderLocked = 0U;
-    uint8_t isSessionLocked = 0U;
     PeerConnectionRollingBufferPacket_t * pRollingBufferPacket = NULL;
     IceControllerResult_t resultIceController;
     uint8_t bufferAfterEncrypt = 1;
@@ -122,19 +121,6 @@ static PeerConnectionResult_t ResendSrtpPacket( PeerConnectionSession_t * pSessi
         {
             LogError( ( "Fail to take sender mutex" ) );
             ret = PEER_CONNECTION_RESULT_FAIL_TAKE_SENDER_MUTEX;
-        }
-    }
-
-    if( ret == PEER_CONNECTION_RESULT_OK )
-    {
-        if( pthread_mutex_lock( &( pSession->srtpSessionMutex ) ) == 0 )
-        {
-            isSessionLocked = 1U;
-        }
-        else
-        {
-            LogError( ( "Fail to take SRTP session mutex" ) );
-            ret = PEER_CONNECTION_RESULT_FAIL_TAKE_SRTP_MUTEX;
         }
     }
 
@@ -207,11 +193,6 @@ static PeerConnectionResult_t ResendSrtpPacket( PeerConnectionSession_t * pSessi
         {
             LogDebug( ( "Re-send RTP successfully, RTP seq: %u, SSRC: 0x%x", rtpSeq, ssrc ) );
         }
-    }
-
-    if( isSessionLocked != 0U )
-    {
-        pthread_mutex_unlock( &( pSession->srtpSessionMutex ) );
     }
 
     if( isSenderLocked )

--- a/examples/peer_connection/peer_connection_srtp.c
+++ b/examples/peer_connection/peer_connection_srtp.c
@@ -277,6 +277,11 @@ PeerConnectionResult_t PeerConnectionSrtp_Init( PeerConnectionSession_t * pSessi
         }
     }
 
+    if( isLocked != 0U )
+    {
+        pthread_mutex_unlock( &( pSession->srtpSessionMutex ) );
+    }
+
     if( ret == PEER_CONNECTION_RESULT_OK )
     {
         /* Initialize Rolling buffers. */
@@ -391,11 +396,6 @@ PeerConnectionResult_t PeerConnectionSrtp_Init( PeerConnectionSession_t * pSessi
         }
     }
 
-    if( isLocked != 0U )
-    {
-        pthread_mutex_unlock( &( pSession->srtpSessionMutex ) );
-    }
-
     return ret;
 }
 
@@ -462,6 +462,7 @@ PeerConnectionResult_t PeerConnectionSrtp_DeInit( PeerConnectionSession_t * pSes
         {
             PeerConnectionRollingBuffer_Free( &pSession->videoSrtpSender.txRollingBuffer );
             pthread_mutex_unlock( &( pSession->videoSrtpSender.senderMutex ) );
+            pthread_mutex_destroy( &( pSession->videoSrtpSender.senderMutex ) );
         }
 
         /* Clean up Audio SRTP Sender */


### PR DESCRIPTION
*Issue #, if available:*
Dead lock happens while resend.

*Description of changes:*
Remove taking session lock in resend flow. It takes the lock while constructing SRTP packet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
