### PR TITLE
Update SCTP streams reset log

### DIFF
--- a/examples/libusrsctp/sctp_utils.c
+++ b/examples/libusrsctp/sctp_utils.c
@@ -789,7 +789,7 @@ SctpUtilsResult_t Sctp_CloseDataChannel( SctpSession_t * pSctpSession,
                                 pSrs,
                                 ( socklen_t ) len ) < 0 )
         {
-            LogError( ( "Error closing the data channel stream!" ) );
+            LogDebug( ( "Failed to reset SCTP streams - this is expected if viewer was already closed." ) );
             retStatus = SCTP_UTILS_RESULT_FAIL;
         }
     }


### PR DESCRIPTION
Description of changes:

Changed log level from ERROR to DEBUG for SCTP stream reset failure. This change reflects that the behaviour is expected if viewer was already closed, not an error condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
