### PR TITLE
Add metrics logging with METRIC_PRINT_ENABLED flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,27 @@ Before using JoinStorageSession, Set up Signaling Channel with Video Stream :
 
 For detailed setup instructions, refer to: https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html
 
+### Enabling metrics logging
+
+METRIC_PRINT_ENABLED flag enables detailed metrics logging for WebRTC setup. It logs the following time for each connection :
+   - Duration to describe Signaling Channel
+   - Duration to get Signaling Endpoints
+   - Duration to get Ice Server List
+   - Duration to connect Websocket Server
+   - Duration to get Authentication Temporary Credentials
+   - Duration to gather ICE Host Candidate
+   - Duration to gather ICE Srflx Candidate
+   - Duration to gather ICE Relay Candidate
+   - Duration to join Storage Session
+   - Duration to find Peer-To-Peer Connection
+   - Duration to DTLS Handshaking Completion
+   - Duration to sending First Frame
+
+Metrics logging is disabled by default in this application (via `METRIC_PRINT_ENABLED`) value set as `0` in `demo_config_template.h`. In order to enable it, set this value to `1`.
+```c
+#define METRIC_PRINT_ENABLED 0
+```
+
 # Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/examples/ice_controller/ice_controller.c
+++ b/examples/ice_controller/ice_controller.c
@@ -526,7 +526,7 @@ static void ProcessCandidatePairs( IceControllerContext_t * pCtx )
         if( pCtx->metrics.isFirstConnectivityRequest == 1 )
         {
             pCtx->metrics.isFirstConnectivityRequest = 0;
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_StartEvent( METRIC_EVENT_ICE_FIND_P2P_CONNECTION );
             #endif
         }

--- a/examples/ice_controller/ice_controller_net.c
+++ b/examples/ice_controller/ice_controller_net.c
@@ -874,7 +874,7 @@ static IceControllerResult_t CheckNomination( IceControllerContext_t * pCtx,
         if( ( pCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_SUCCEEDED ) &&
             ( pCtx->pNominatedSocketContext == NULL ) )
         {
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_EndEvent( METRIC_EVENT_ICE_FIND_P2P_CONNECTION );
             #endif
             LogInfo( ( "Found nomination pair, local/remote candidate ID: 0x%04x / 0x%04x",
@@ -1071,18 +1071,18 @@ void IceControllerNet_AddLocalCandidates( IceControllerContext_t * pCtx )
         {
             if( ICE_CONTROLLER_IS_NAT_CONFIG_SET( pCtx, ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_SEND_HOST ) )
             {
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_StartEvent( METRIC_EVENT_ICE_GATHER_HOST_CANDIDATES );
                 #endif
                 AddHostCandidate( pCtx, &pCtx->localEndpoints[i] );
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_EndEvent( METRIC_EVENT_ICE_GATHER_HOST_CANDIDATES );
                 #endif
             }
 
             if( ICE_CONTROLLER_IS_NAT_CONFIG_SET( pCtx, ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_SEND_SRFLX ) )
             {
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_StartEvent( METRIC_EVENT_ICE_GATHER_SRFLX_CANDIDATES );
                 #endif
                 AddSrflxCandidate( pCtx, &pCtx->localEndpoints[i] );
@@ -1091,7 +1091,7 @@ void IceControllerNet_AddLocalCandidates( IceControllerContext_t * pCtx )
 
         if( ICE_CONTROLLER_IS_NAT_CONFIG_SET( pCtx, ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_SEND_RELAY ) )
         {
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_StartEvent( METRIC_EVENT_ICE_GATHER_RELAY_CANDIDATES );
             #endif
             AddRelayCandidates( pCtx );
@@ -1187,7 +1187,7 @@ IceControllerResult_t IceControllerNet_HandleStunPacket( IceControllerContext_t 
                 }
 
                 pCtx->metrics.pendingSrflxCandidateNum--;
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 if( pCtx->metrics.pendingSrflxCandidateNum == 0 )
                 {
                     Metric_EndEvent( METRIC_EVENT_ICE_GATHER_SRFLX_CANDIDATES );
@@ -1214,7 +1214,7 @@ IceControllerResult_t IceControllerNet_HandleStunPacket( IceControllerContext_t 
                     }
 
                     pCtx->metrics.pendingRelayCandidateNum--;
-                    #if ( METRIC_PRINT_ENABLED != 0 )
+                    #if METRIC_PRINT_ENABLED
                     if( pCtx->metrics.pendingRelayCandidateNum == 0 )
                     {
                         Metric_EndEvent( METRIC_EVENT_ICE_GATHER_RELAY_CANDIDATES );

--- a/examples/master/demo_config_template.h
+++ b/examples/master/demo_config_template.h
@@ -51,4 +51,8 @@
 #define JOIN_STORAGE_SESSION 0
 #endif
 
+#ifndef METRIC_PRINT_ENABLED
+#define METRIC_PRINT_ENABLED 0
+#endif
+
 #endif /* DEMO_CONFIG_H */

--- a/examples/master/main.c
+++ b/examples/master/main.c
@@ -1236,7 +1236,7 @@ static int OnSignalingMessageReceived( SignalingMessage_t * pSignalingMessage,
     switch( pSignalingMessage->messageType )
     {
         case SIGNALING_TYPE_MESSAGE_SDP_OFFER:
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_StartEvent( METRIC_EVENT_SENDING_FIRST_FRAME );
             #endif
             HandleSdpOffer( &demoContext,
@@ -1399,7 +1399,7 @@ int main()
         signal( SIGINT, terminateHandler );
 
         /* Initialize metrics. */
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_Init();
         #endif
     }

--- a/examples/metric/metric.c
+++ b/examples/metric/metric.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 /* Exclude the entire file if METRIC print flag is not enabled. */
-#if ( METRIC_PRINT_ENABLED != 0 )
+#if METRIC_PRINT_ENABLED
 
     #define METRIC_PRINT_INTERVAL_MS ( 10000 )
 
@@ -17,9 +17,6 @@
     /* Calculate the duration in miliseconds from start & end time. */
     static uint64_t CalculateEventDurationMs( uint64_t startTimeUs,
                                           uint64_t endTimeUs );
-
-    /* The task to print metric regularly. */
-    static void * Metric_Task( void * pParameter );
 
     static const char * ConvertEventToString( MetricEvent_t event )
     {
@@ -86,25 +83,9 @@
         return ( uint64_t ) nowTime.tv_sec * 1000 * 1000 * 1000 + ( uint64_t ) nowTime.tv_nsec;
     }
 
-    static void * Metric_Task( void * pParameter )
-    {
-        ( void ) pParameter;
-
-        for( ;; )
-        {
-            Metric_PrintMetrics();
-
-            //vTaskDelay( pdMS_TO_TICKS( METRIC_PRINT_INTERVAL_MS ) );
-            usleep( METRIC_PRINT_INTERVAL_MS * 1000 );
-        }
-
-        return 0;
-    }
-
     void Metric_Init( void )
     {
         int retval;
-        pthread_t thread;
 
         memset( &context, 0, sizeof( MetricContext_t ) );
 
@@ -116,16 +97,6 @@
         else
         {
             context.isInit = 1U;
-        }
-
-        /* Create task for video Tx. */
-        retval = pthread_create( &( thread ),
-                                NULL,
-                                Metric_Task,
-                                NULL );
-        if( retval != 0 )
-        {
-            LogError( ( "xTaskCreate(MetricTask) failed" ) );
         }
     }
 
@@ -167,7 +138,6 @@
     {
         int i;
         MetricEventRecord_t * pEventRecord;
-        //static char runTimeStatsBuffer[ 4096 ];
 
         if( ( context.isInit == 1U ) &&
             ( pthread_mutex_lock( &( context.mutex ) ) == 0 ) )
@@ -185,10 +155,6 @@
                 }
             }
 
-            //LogInfo( ( "Remaining free heap size: %u", xPortGetFreeHeapSize() ) );
-
-            // vTaskGetRunTimeStats( runTimeStatsBuffer );
-            // LogInfo( ( " == Run Time Stat Start ==\n%s\n == Run Time Stat End ==", runTimeStatsBuffer ) );
             LogInfo( ( "================================ Print Metrics End ================================" ) );
 
             pthread_mutex_unlock( &( context.mutex ) );

--- a/examples/metric/metric.h
+++ b/examples/metric/metric.h
@@ -9,67 +9,64 @@ extern "C" {
 #endif
 /* *INDENT-ON* */
 
-#if ( METRIC_PRINT_ENABLED != 0 )
+#include <stdio.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include "demo_config.h"
 
-    #include <stdio.h>
-    #include <inttypes.h>
-    #include <pthread.h>
+typedef enum MetricEvent
+{
+    METRIC_EVENT_NONE = 0,
 
-    typedef enum MetricEvent
-    {
-        METRIC_EVENT_NONE = 0,
+    /* Signaling Events */
+    METRIC_EVENT_SIGNALING_DESCRIBE_CHANNEL,
+    METRIC_EVENT_SIGNALING_GET_ENDPOINTS,
+    METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST,
+    METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER,
+    METRIC_EVENT_SIGNALING_GET_CREDENTIALS,
+    METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION,
 
-        /* Signaling Events */
-        METRIC_EVENT_SIGNALING_DESCRIBE_CHANNEL,
-        METRIC_EVENT_SIGNALING_GET_ENDPOINTS,
-        METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST,
-        METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER,
-        METRIC_EVENT_SIGNALING_GET_CREDENTIALS,
-        METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION,
+    /* ICE Events. */
+    METRIC_EVENT_ICE_GATHER_HOST_CANDIDATES,
+    METRIC_EVENT_ICE_GATHER_SRFLX_CANDIDATES,
+    METRIC_EVENT_ICE_GATHER_RELAY_CANDIDATES,
+    METRIC_EVENT_ICE_FIND_P2P_CONNECTION,
 
-        /* ICE Events. */
-        METRIC_EVENT_ICE_GATHER_HOST_CANDIDATES,
-        METRIC_EVENT_ICE_GATHER_SRFLX_CANDIDATES,
-        METRIC_EVENT_ICE_GATHER_RELAY_CANDIDATES,
-        METRIC_EVENT_ICE_FIND_P2P_CONNECTION,
+    /* Peer Connection Events. */
+    METRIC_EVENT_PC_DTLS_HANDSHAKING,
 
-        /* Peer Connection Events. */
-        METRIC_EVENT_PC_DTLS_HANDSHAKING,
+    /* Combine case. */
+    METRIC_EVENT_SENDING_FIRST_FRAME,
 
-        /* Combine case. */
-        METRIC_EVENT_SENDING_FIRST_FRAME,
+    METRIC_EVENT_MAX,
+} MetricEvent_t;
 
-        METRIC_EVENT_MAX,
-    } MetricEvent_t;
+typedef enum MetricEventState
+{
+    METRIC_EVENT_STATE_NONE = 0,
+    METRIC_EVENT_STATE_RECORDING,
+    METRIC_EVENT_STATE_RECORDED,
+} MetricEventState_t;
 
-    typedef enum MetricEventState
-    {
-        METRIC_EVENT_STATE_NONE = 0,
-        METRIC_EVENT_STATE_RECORDING,
-        METRIC_EVENT_STATE_RECORDED,
-    } MetricEventState_t;
+typedef struct MetricEventRecord
+{
+    MetricEventState_t state;
+    uint64_t startTimeUs;
+    uint64_t endTimeUs;
+} MetricEventRecord_t;
 
-    typedef struct MetricEventRecord
-    {
-        MetricEventState_t state;
-        uint64_t startTimeUs;
-        uint64_t endTimeUs;
-    } MetricEventRecord_t;
+typedef struct MetricContext
+{
+    uint8_t isInit;
+    MetricEventRecord_t eventRecords[ METRIC_EVENT_MAX ];
+    pthread_mutex_t mutex;
+} MetricContext_t;
 
-    typedef struct MetricContext
-    {
-        uint8_t isInit;
-        MetricEventRecord_t eventRecords[ METRIC_EVENT_MAX ];
-        pthread_mutex_t mutex;
-    } MetricContext_t;
-
-    void Metric_Init( void );
-    void Metric_StartEvent( MetricEvent_t event );
-    void Metric_EndEvent( MetricEvent_t event );
-    void Metric_PrintMetrics( void );
-    void Metric_ResetEvent( void );
-
-#endif /* METRIC_PRINT_ENABLED */
+void Metric_Init( void );
+void Metric_StartEvent( MetricEvent_t event );
+void Metric_EndEvent( MetricEvent_t event );
+void Metric_PrintMetrics( void );
+void Metric_ResetEvent( void );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/examples/peer_connection/peer_connection.c
+++ b/examples/peer_connection/peer_connection.c
@@ -697,7 +697,7 @@ static int32_t HandleIceEventCallback( void * pCustomContext,
                 break;
             case ICE_CONTROLLER_CB_EVENT_PEER_TO_PEER_CONNECTION_FOUND:
                 /* Start DTLS handshaking. */
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_StartEvent( METRIC_EVENT_PC_DTLS_HANDSHAKING );
                 #endif
                 ret = StartDtlsHandshake( pSession );
@@ -899,7 +899,7 @@ static int32_t OnDtlsHandshakeComplete( PeerConnectionSession_t * pSession )
     uint32_t i;
 
     LogDebug( ( "Complete DTLS handshaking." ) );
-    #if ( METRIC_PRINT_ENABLED != 0 )
+    #if METRIC_PRINT_ENABLED
     Metric_EndEvent( METRIC_EVENT_PC_DTLS_HANDSHAKING );
     #endif
     /* Verify remote fingerprint (if remote cert fingerprint is the expected one) */
@@ -2128,6 +2128,8 @@ PeerConnectionResult_t PeerConnection_CloseSession( PeerConnectionSession_t * pS
 
     if( ret == PEER_CONNECTION_RESULT_OK )
     {
+        /* Reset metrics. */
+        pSession->iceControllerContext.metrics.isFirstConnectivityRequest = 1;
         ret = PeerConnection_ResetTimer( pSession );
         if( ret != PEER_CONNECTION_RESULT_OK )
         {
@@ -2135,6 +2137,10 @@ PeerConnectionResult_t PeerConnection_CloseSession( PeerConnectionSession_t * pS
         }
     }
 
+    #if METRIC_PRINT_ENABLED
+    Metric_PrintMetrics();
+    Metric_ResetEvent();
+    #endif
     return ret;
 }
 

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
@@ -327,7 +327,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteG711Frame( PeerConnectionSession_
             bytesSent += pRollingBufferPacket->rtpPacket.payloadLength;
         }
 
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         if( ret == PEER_CONNECTION_RESULT_OK )
         {
             Metric_EndEvent( METRIC_EVENT_SENDING_FIRST_FRAME );

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
@@ -342,7 +342,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteH264Frame( PeerConnectionSession_
             bytesSent += pRollingBufferPacket->rtpPacket.payloadLength;
         }
 
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         if( ret == PEER_CONNECTION_RESULT_OK )
         {
             Metric_EndEvent( METRIC_EVENT_SENDING_FIRST_FRAME );

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
@@ -330,7 +330,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteOpusFrame( PeerConnectionSession_
             bytesSent += pRollingBufferPacket->rtpPacket.payloadLength;
         }
 
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         if( ret == PEER_CONNECTION_RESULT_OK )
         {
             Metric_EndEvent( METRIC_EVENT_SENDING_FIRST_FRAME );

--- a/examples/signaling_controller/signaling_controller.c
+++ b/examples/signaling_controller/signaling_controller.c
@@ -832,12 +832,12 @@ static SignalingControllerResult_t ConnectToSignalingService( SignalingControlle
             if( ( pCtx->expirationSeconds == 0 ) ||
                 ( currentTimeSeconds >= pCtx->expirationSeconds - SIGNALING_CONTROLLER_FETCH_CREDS_GRACE_PERIOD_SEC ) )
             {
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_StartEvent( METRIC_EVENT_SIGNALING_GET_CREDENTIALS );
                 #endif
                 ret = FetchTemporaryCredentials( pCtx,
                                                  &( pConnectInfo->awsIotCreds ) );
-                #if ( METRIC_PRINT_ENABLED != 0 )
+                #if METRIC_PRINT_ENABLED
                 Metric_EndEvent( METRIC_EVENT_SIGNALING_GET_CREDENTIALS );
                 #endif
             }
@@ -866,44 +866,44 @@ static SignalingControllerResult_t ConnectToSignalingService( SignalingControlle
 
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )
     {
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_StartEvent( METRIC_EVENT_SIGNALING_DESCRIBE_CHANNEL );
         #endif
         ret = DescribeSignalingChannel( pCtx, &( pConnectInfo->channelName ) );
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_EndEvent( METRIC_EVENT_SIGNALING_DESCRIBE_CHANNEL );
         #endif
     }
 
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )
     {
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_StartEvent( METRIC_EVENT_SIGNALING_GET_ENDPOINTS );
         #endif
         ret = GetSignalingChannelEndpoints( pCtx, pConnectInfo->enableStorageSession );
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_EndEvent( METRIC_EVENT_SIGNALING_GET_ENDPOINTS );
         #endif
     }
 
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )
     {
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_StartEvent( METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST );
         #endif
         ret = GetIceServerConfigs( pCtx );
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_EndEvent( METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST );
         #endif
     }
 
     if( ret == SIGNALING_CONTROLLER_RESULT_OK )
     {
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_StartEvent( METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER );
         #endif
         ret = ConnectToWssEndpoint( pCtx );
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_EndEvent( METRIC_EVENT_SIGNALING_CONNECT_WSS_SERVER );
         #endif
     }
@@ -912,11 +912,11 @@ static SignalingControllerResult_t ConnectToSignalingService( SignalingControlle
     if( ( ret == SIGNALING_CONTROLLER_RESULT_OK ) &&
         ( pConnectInfo->enableStorageSession != 0 ) )
     {
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_StartEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
         #endif
         ret = JoinStorageSession( pCtx );
-        #if ( METRIC_PRINT_ENABLED != 0 )
+        #if METRIC_PRINT_ENABLED
         Metric_EndEvent( METRIC_EVENT_SIGNALING_JOIN_STORAGE_SESSION );
         #endif
     }
@@ -1155,11 +1155,11 @@ SignalingControllerResult_t SignalingController_QueryIceServerConfigs( Signaling
             ( pCtx->iceServerConfigExpirationSec < currentTimeSec ) )
         {
             LogInfo( ( "Ice server configs expired. Refresing Configs." ) );
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_StartEvent( METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST );
             #endif
             ret = GetIceServerConfigs( pCtx );
-            #if ( METRIC_PRINT_ENABLED != 0 )
+            #if METRIC_PRINT_ENABLED
             Metric_EndEvent( METRIC_EVENT_SIGNALING_GET_ICE_SERVER_LIST );
             #endif
         }


### PR DESCRIPTION
*Issue #, if available:*
The metrics was not resetting. 

*Description of changes:*
1. Introduced METRIC_PRINT_ENABLED flag to enable metrics logging.
2. Metrics is reset after every closed peer connection to avoid stale prints.
3. Removed thread for metrics which was printing older values repeatedly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
