### PR TITLE
Configure LWS Logs

### DIFF
--- a/examples/networking/networking.c
+++ b/examples/networking/networking.c
@@ -1389,7 +1389,9 @@ NetworkingResult_t Networking_HttpInit( NetworkingHttpContext_t * pHttpCtx,
             creationInfo.client_ssl_private_key_filepath = pCreds->pDeviceKeyPath;
         }
 
-        lws_set_log_level( LLL_NOTICE | LLL_WARN | LLL_ERR, NULL );
+         /* Configure libwebsockets logging based on application log level */
+         Networking_ConfigureLwsLogging( LIBRARY_LOG_LEVEL );
+
         pHttpCtx->pLwsContext = lws_create_context( &( creationInfo ) );
 
         if( pHttpCtx->pLwsContext == NULL )
@@ -1681,7 +1683,9 @@ NetworkingResult_t Networking_WebsocketConnect( NetworkingWebsocketContext_t * p
                 creationInfo.client_ssl_private_key_filepath = pWebsocketCtx->sslCreds.pDeviceKeyPath;
             }
 
-            lws_set_log_level( LLL_NOTICE | LLL_WARN | LLL_ERR, NULL );
+            /* Configure libwebsockets logging based on application log level */
+            Networking_ConfigureLwsLogging( LIBRARY_LOG_LEVEL );
+
             pWebsocketCtx->pLwsContext = lws_create_context( &creationInfo );
             if( pWebsocketCtx->pLwsContext == NULL )
             {

--- a/examples/networking/networking.h
+++ b/examples/networking/networking.h
@@ -224,4 +224,17 @@ NetworkingResult_t Networking_WebsocketSend( NetworkingWebsocketContext_t * pWeb
 
 NetworkingResult_t Networking_WebsocketSignal( NetworkingWebsocketContext_t * pWebsocketCtx );
 
+/**
+ * @brief Configure libwebsockets logging based on the application's log level.
+ *
+ * This function maps the application's log levels (LOG_ERROR, LOG_WARN, etc.)
+ * to libwebsockets log levels (LLL_ERR, LLL_WARN, etc.) and configures
+ * libwebsockets to use the appropriate log level.
+ *
+ * @param[in] logLevel The application's log level.
+ *
+ * @return NetworkingResult_t Returns NETWORKING_RESULT_OK on success.
+ */
+NetworkingResult_t Networking_ConfigureLwsLogging( uint32_t logLevel );
+
 /*----------------------------------------------------------------------------*/

--- a/examples/networking/networking_utils/configure_lws_logging.c
+++ b/examples/networking/networking_utils/configure_lws_logging.c
@@ -1,0 +1,44 @@
+#include "../networking.h"
+#include "logging.h"
+
+NetworkingResult_t Networking_ConfigureLwsLogging( uint32_t logLevel )
+{
+    NetworkingResult_t ret = NETWORKING_RESULT_OK;
+    int lws_levels = 0;
+    LogInfo(("Log level: %d", logLevel));
+    /* Map application log levels to libwebsockets log levels */
+    if( logLevel == LOG_NONE )
+    {
+        lws_levels = 0;
+    }
+
+    if( logLevel >= LOG_ERROR )
+    {
+        lws_levels |= LLL_ERR;
+    }
+
+    if( logLevel >= LOG_WARN )
+    {
+        lws_levels |= LLL_WARN;
+    }
+
+    if( logLevel >= LOG_INFO )
+    {
+        lws_levels |= LLL_NOTICE;
+    }
+
+    if( logLevel >= LOG_DEBUG )
+    {
+        lws_levels |= LLL_INFO;
+    }
+
+    if( logLevel >= LOG_VERBOSE )
+    {
+        lws_levels |= LLL_DEBUG;
+    }
+
+    /* Configure libwebsockets with the mapped log levels */
+    lws_set_log_level( lws_levels, NULL );
+
+    return ret;
+}

--- a/examples/networking/networking_utils/configure_lws_logging.c
+++ b/examples/networking/networking_utils/configure_lws_logging.c
@@ -5,7 +5,7 @@ NetworkingResult_t Networking_ConfigureLwsLogging( uint32_t logLevel )
 {
     NetworkingResult_t ret = NETWORKING_RESULT_OK;
     int lws_levels = 0;
-    LogInfo(("Log level: %d", logLevel));
+  
     /* Map application log levels to libwebsockets log levels */
     if( logLevel == LOG_NONE )
     {


### PR DESCRIPTION
*Description of changes:*

Updated the LibWebSocket (LWS) logging configuration to align with KVS WebRTC SDK C [Release v1.12.1](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/commit/cf817bc5d18f3e4bd499c6b0f9a68c6f4d7e01de). 
This change allows more control over logging levels of LWS.

*Test Steps*:

Set the LIBRARY_LOG_LEVEL according to your requirements, and LWS logs will be mapped accordingly.
```
// Build the application
cmake -S . -B build
make -C build

// Run the application
./build/WebRTCLinuxApplicationMaster
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
