### PR TITLE
Close Peer Connection when Socket FD is unreachable

### DIFF
--- a/examples/ice_controller/ice_controller_net.c
+++ b/examples/ice_controller/ice_controller_net.c
@@ -1089,6 +1089,29 @@ IceControllerResult_t IceControllerNet_SendPacket( IceControllerContext_t * pCtx
          */
         ( void ) Ice_CloseCandidate( &pCtx->iceContext, pSocketContext->pLocalCandidate );
         IceControllerNet_FreeSocketContext( pCtx, pSocketContext );
+
+        if( pSocketContext == pCtx->pNominatedSocketContext )
+        {
+            /* Disconnecting nominated socket connection, closing. */
+            LogWarn( ( "Unable to send packet through nominated socket, closing session: %.*s",
+                     ( int ) pCtx->iceContext.creds.combinedUsernameLength,
+                     pCtx->iceContext.creds.pCombinedUsername ) );
+
+            /* Notify peer connection for closing the connection. */
+            if( pCtx->onIceEventCallbackFunc )
+            {
+                pCtx->onIceEventCallbackFunc( pCtx->pOnIceEventCustomContext,
+                                              ICE_CONTROLLER_CB_EVENT_ICE_CLOSE_NOTIFY,
+                                              NULL );
+                /* Re-set the timer. */
+                IceController_UpdateTimerInterval( pCtx,
+                                                   ICE_CONTROLLER_CLOSING_INTERVAL_MS );
+            }
+            else
+            {
+                LogError( ( "There is no ICE event callback function set." ) );
+            }
+        }
     }
 
     return ret;


### PR DESCRIPTION
Description
-------------
This addresses the issue where the application fails to recover after a WiFi reconnection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
