### PR TITLE
Change the default video codec in template

### DIFF
--- a/examples/demo_config/demo_config_template.h
+++ b/examples/demo_config/demo_config_template.h
@@ -51,7 +51,7 @@
 
 #define AWS_MAX_VIEWER_NUM ( 2 )
 
-/* Audio format setting - currently only opus codec is supported in Linux environments */
+/* Audio format setting - currently only opus codec is supported in Linux environments. */
 #define AUDIO_OPUS         1
 
 /* Join Storage Session setting. */
@@ -59,8 +59,9 @@
 #define JOIN_STORAGE_SESSION 0
 #endif
 
-#define USE_VIDEO_CODEC_H264 0
-#define USE_VIDEO_CODEC_H265 1
+/* Video format setting - H264 is the default codec in Linux environments. */
+#define USE_VIDEO_CODEC_H264 1
+#define USE_VIDEO_CODEC_H265 0
 #if ( USE_VIDEO_CODEC_H264 + USE_VIDEO_CODEC_H265 ) != 1
     #error only one of video codec should be set
 #endif


### PR DESCRIPTION
### Description of changes:

Changed the default video codec in the `demo_config_template.h` to H264.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
