### PR TITLE
Optimize SRTP sender lock handling and initialize buffer structures

### DIFF
--- a/examples/peer_connection/peer_connection.c
+++ b/examples/peer_connection/peer_connection.c
@@ -591,7 +591,7 @@ static int32_t OnIceEventClosing( PeerConnectionSession_t * pSession )
     {
         result = SendPeerConnectionEvent( pSession,
                                           PEER_CONNECTION_SESSION_REQUEST_TYPE_ICE_CLOSING,
-                                          NULL ,
+                                          NULL,
                                           0U );
         if( result != PEER_CONNECTION_RESULT_OK )
         {
@@ -2230,8 +2230,8 @@ PeerConnectionResult_t PeerConnection_WriteFrame( PeerConnectionSession_t * pSes
         else if( TRANSCEIVER_IS_CODEC_ENABLED( pTransceiver->codecBitMap,
                                                TRANSCEIVER_RTC_CODEC_H265_BIT ) )
         {
-            ret = PeerConnectionSrtp_WriteH265Frame( pSession, 
-                                                     pTransceiver, 
+            ret = PeerConnectionSrtp_WriteH265Frame( pSession,
+                                                     pTransceiver,
                                                      pFrame );
         }
         else

--- a/examples/peer_connection/peer_connection_codec_helper/include/peer_connection_codec_helper.h
+++ b/examples/peer_connection/peer_connection_codec_helper/include/peer_connection_codec_helper.h
@@ -54,7 +54,7 @@
 #define PEER_CONNECTION_SRTP_RTX_WRITE_RESERVED_BYTES ( 2 )
 
 #define PEER_CONNECTION_SRTP_H264_MAX_NALUS_IN_A_FRAME        ( 64 )
-#define PEER_CONNECTION_SRTP_H265_MAX_NALUS_IN_A_FRAME        ( 64 )                                                                                      
+#define PEER_CONNECTION_SRTP_H265_MAX_NALUS_IN_A_FRAME        ( 64 )
 #define PEER_CONNECTION_SRTP_RTP_PAYLOAD_MAX_LENGTH      ( 1200 )
 
 #define PEER_CONNECTION_SRTP_VIDEO_CLOCKRATE ( uint32_t ) 90000

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
@@ -366,18 +366,22 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteG711Frame( PeerConnectionSession_
         #endif
     }
 
+    if( packetSent != 0 )
+    {
+        if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
+        {
+            pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
+            pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
+        }
+
+        pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
+        pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
+    }
+
     if( isLocked )
     {
         pthread_mutex_unlock( &( pSrtpSender->senderMutex ) );
     }
 
-    if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
-    {
-        pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
-        pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
-    }
-
-    pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
-    pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
     return ret;
 }

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
@@ -310,7 +310,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteH264Frame( PeerConnectionSession_
                 RtcpTwccManager_AddPacketInfo( &pSession->pCtx->rtcpTwccManager,
                                                &packetInfo );
                 #endif /* ENABLE_TWCC_SUPPORT */
-                
+
                 pSession->rtpConfig.twccSequence++;
             }
 
@@ -381,19 +381,22 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteH264Frame( PeerConnectionSession_
         #endif
     }
 
+    if( packetSent != 0 )
+    {
+        if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
+        {
+            pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
+            pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
+        }
+
+        pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
+        pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
+    }
+
     if( isLocked )
     {
         pthread_mutex_unlock( &( pSrtpSender->senderMutex ) );
     }
-
-    if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
-    {
-        pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
-        pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
-    }
-
-    pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
-    pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
 
     return ret;
 }

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
@@ -288,7 +288,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteOpusFrame( PeerConnectionSession_
                 pRollingBufferPacket->twccExtensionPayload = PEER_CONNECTION_SRTP_GET_TWCC_PAYLOAD( pSession->rtpConfig.twccId,
                                                                                                     pSession->rtpConfig.twccSequence );
                 pRollingBufferPacket->rtpPacket.header.extension.pExtensionPayload = &pRollingBufferPacket->twccExtensionPayload;
-                
+
                 #if ENABLE_TWCC_SUPPORT
                 memset( &packetInfo, 0, sizeof( TwccPacketInfo_t ) );
                 packetInfo.packetSize = packetOpus.packetDataLength;
@@ -298,7 +298,7 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteOpusFrame( PeerConnectionSession_
                 RtcpTwccManager_AddPacketInfo( &pSession->pCtx->rtcpTwccManager,
                                                &packetInfo );
                 #endif /* ENABLE_TWCC_SUPPORT */
-                
+
                 pSession->rtpConfig.twccSequence++;
             }
 
@@ -369,19 +369,22 @@ PeerConnectionResult_t PeerConnectionSrtp_WriteOpusFrame( PeerConnectionSession_
         #endif
     }
 
+    if( packetSent != 0 )
+    {
+        if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
+        {
+            pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
+            pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
+        }
+
+        pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
+        pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
+    }
+
     if( isLocked )
     {
         pthread_mutex_unlock( &( pSrtpSender->senderMutex ) );
     }
-
-    if( pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs == 0 )
-    {
-        pTransceiver->rtpSender.rtpFirstFrameWallClockTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
-        pTransceiver->rtpSender.rtpTimeOffset = randomRtpTimeoffset;
-    }
-
-    pTransceiver->rtcpStats.rtpPacketsTransmitted += packetSent;
-    pTransceiver->rtcpStats.rtpBytesTransmitted += bytesSent;
 
     return ret;
 }

--- a/examples/peer_connection/peer_connection_data_types.h
+++ b/examples/peer_connection/peer_connection_data_types.h
@@ -232,6 +232,7 @@ typedef struct PeerConnectionRollingBufferPacket
 
 typedef struct PeerConnectionRollingBuffer
 {
+    uint8_t isInit;
     RtpPacketQueue_t packetQueue;
     size_t maxSizePerPacket;
     size_t capacity;     /* Buffer duration * highest expected bitrate (in bps) / 8 / maxPacketSize. */
@@ -249,6 +250,7 @@ typedef struct PeerConnectionJitterBufferPacket
 
 typedef struct PeerConnectionJitterBuffer
 {
+    uint8_t isInit;
     uint8_t isStart;     /* The jitter buffer starts to receive packet or not. */
     size_t capacity;     /* The total number of packets that packet queue can store. */
     uint32_t clockRate;     /* The clock rate based on the codec. For example: the clock rate is 90000 if the chosen RTP is H264/90000. */
@@ -339,6 +341,7 @@ typedef struct PeerConnectionSrtpSender
 
     /* Mutex to protect sender info like rolling buffer. */
     pthread_mutex_t senderMutex;
+    uint8_t isSenderMutexInit;
 } PeerConnectionSrtpSender_t;
 
 typedef struct PeerConnectionSrtpReceiver

--- a/examples/peer_connection/peer_connection_jitter_buffer.c
+++ b/examples/peer_connection/peer_connection_jitter_buffer.c
@@ -377,7 +377,11 @@ PeerConnectionResult_t PeerConnectionJitterBuffer_Create( PeerConnectionJitterBu
             LogError( ( "Codec is not supported, codec bit map: 0x%x", ( int ) codec ) );
             ret = PEER_CONNECTION_RESULT_UNKNOWN_TX_CODEC;
         }
+    }
 
+    if( ret == PEER_CONNECTION_RESULT_OK )
+    {
+        pJitterBuffer->isInit = 1U;
     }
 
     return ret;
@@ -393,9 +397,20 @@ void PeerConnectionJitterBuffer_Free( PeerConnectionJitterBuffer_t * pJitterBuff
                     pJitterBuffer ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
+    else if( pJitterBuffer->isInit == 0U )
+    {
+        LogError( ( "Jitter buffer is not initialized yet." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else
+    {
+        /* Empty else marker. */
+    }
 
     if( ret == PEER_CONNECTION_RESULT_OK )
     {
+        pJitterBuffer->isInit = 0U;
+
         ( void ) ParseFramesInJitterBuffer( pJitterBuffer, 1 );
     }
 
@@ -417,6 +432,11 @@ PeerConnectionResult_t PeerConnectionJitterBuffer_AllocateBuffer( PeerConnection
         ( ppOutPacket == NULL ) )
     {
         LogError( ( "Invalid input, pJitterBuffer: %p, ppOutPacket: %p", pJitterBuffer, ppOutPacket ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else if( pJitterBuffer->isInit == 0U )
+    {
+        LogError( ( "Jitter buffer is not initialized yet or it has been freed." ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
     else if( packetBufferSize == 0 )
@@ -459,6 +479,15 @@ PeerConnectionResult_t PeerConnectionJitterBuffer_GetPacket( PeerConnectionJitte
         LogError( ( "Invalid input, pJitterBuffer: %p, ppOutPacket: %p", pJitterBuffer, ppOutPacket ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
+    else if( pJitterBuffer->isInit == 0U )
+    {
+        LogError( ( "Jitter buffer is not initialized yet or it has been freed." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else
+    {
+        /* Empty else marker. */
+    }
 
     if( ret == PEER_CONNECTION_RESULT_OK )
     {
@@ -488,6 +517,15 @@ PeerConnectionResult_t PeerConnectionJitterBuffer_Push( PeerConnectionJitterBuff
     {
         LogError( ( "Invalid input, pJitterBuffer: %p, pPacket: %p", pJitterBuffer, pPacket ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else if( pJitterBuffer->isInit == 0U )
+    {
+        LogError( ( "Jitter buffer is not initialized yet or it has been freed." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else
+    {
+        /* Empty else marker. */
     }
 
     if( ret == PEER_CONNECTION_RESULT_OK )
@@ -546,6 +584,15 @@ PeerConnectionResult_t PeerConnectionJitterBuffer_FillFrame( PeerConnectionJitte
     {
         LogError( ( "Invalid input, pJitterBuffer: %p, pOutBuffer: %p, pOutBufferLength: %p, pRtpTimestamp: %p", pJitterBuffer, pOutBuffer, pOutBufferLength, pRtpTimestamp ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else if( pJitterBuffer->isInit == 0U )
+    {
+        LogError( ( "Jitter buffer is not initialized yet or it has been freed." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else
+    {
+        /* Empty else marker. */
     }
 
     if( ret == PEER_CONNECTION_RESULT_OK )

--- a/examples/peer_connection/peer_connection_rolling_buffer.c
+++ b/examples/peer_connection/peer_connection_rolling_buffer.c
@@ -76,6 +76,11 @@ PeerConnectionResult_t PeerConnectionRollingBuffer_Create( PeerConnectionRolling
         }
     }
 
+    if( ret == PEER_CONNECTION_RESULT_OK )
+    {
+        pRollingBuffer->isInit = 1U;
+    }
+
     return ret;
 }
 
@@ -91,9 +96,20 @@ void PeerConnectionRollingBuffer_Free( PeerConnectionRollingBuffer_t * pRollingB
                     pRollingBuffer ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
+    else if( pRollingBuffer->isInit == 0U )
+    {
+        LogError( ( "Rolling buffer is not initialized yet." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else
+    {
+        /* Empty else marker. */
+    }
 
     if( ret == PEER_CONNECTION_RESULT_OK )
     {
+        pRollingBuffer->isInit = 0U;
+
         while( resultRtpPacketQueue == RTP_PACKET_QUEUE_RESULT_OK )
         {
             resultRtpPacketQueue = RtpPacketQueue_Dequeue( &pRollingBuffer->packetQueue,
@@ -125,6 +141,11 @@ PeerConnectionResult_t PeerConnectionRollingBuffer_GetRtpSequenceBuffer( PeerCon
                     pRollingBuffer, ppPacket ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
+    else if( pRollingBuffer->isInit == 0U )
+    {
+        LogWarn( ( "Rolling buffer is not initialized yet or it has been freed." ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
     else if( pRollingBuffer->capacity == 0 )
     {
         LogError( ( "Rolling buffer is not initialized yet." ) );
@@ -143,8 +164,17 @@ PeerConnectionResult_t PeerConnectionRollingBuffer_GetRtpSequenceBuffer( PeerCon
 void PeerConnectionRollingBuffer_DiscardRtpSequenceBuffer( PeerConnectionRollingBuffer_t * pRollingBuffer,
                                                            PeerConnectionRollingBufferPacket_t * pPacket )
 {
-    ( void ) pRollingBuffer;
-    if( pPacket )
+    if( ( pRollingBuffer == NULL ) ||
+        ( pPacket == NULL ) )
+    {
+        LogError( ( "Invalid input, pRollingBuffer: %p, pPacket: %p",
+                    pRollingBuffer, pPacket ) );
+    }
+    else if( pRollingBuffer->isInit == 0U )
+    {
+        LogWarn( ( "Rolling buffer is not initialized yet or it has been freed." ) );
+    }
+    else
     {
         free( pPacket );
     }
@@ -163,6 +193,11 @@ PeerConnectionResult_t PeerConnectionRollingBuffer_SearchRtpSequenceBuffer( Peer
     {
         LogError( ( "Invalid input, pRollingBuffer: %p, ppPacket: %p",
                     pRollingBuffer, ppPacket ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else if( pRollingBuffer->isInit == 0U )
+    {
+        LogWarn( ( "Rolling buffer is not initialized yet or it has been freed." ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
     else if( pRollingBuffer->capacity == 0 )
@@ -210,6 +245,11 @@ PeerConnectionResult_t PeerConnectionRollingBuffer_SetPacket( PeerConnectionRoll
     {
         LogError( ( "Invalid input, pRollingBuffer: %p, pPacket: %p",
                     pRollingBuffer, pPacket ) );
+        ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
+    }
+    else if( pRollingBuffer->isInit == 0U )
+    {
+        LogWarn( ( "Rolling buffer is not initialized yet or it has been freed." ) );
         ret = PEER_CONNECTION_RESULT_BAD_PARAMETER;
     }
     else if( pRollingBuffer->capacity == 0 )


### PR DESCRIPTION
*Issue #, if available:*
A race condition occurred where the sender mutex was accessed after its deallocation. Specifically, the Rx task initiated the connection closure sequence while transmit (Tx) tasks were still actively sending data. This resulted in a use-after-free scenario on the SRTP sender mutex, leading to a crash at taking lock.

[Crash line (this is found on FreeRTOS application, but threoretically there is same issue on Linux application)](https://github.com/awslabs/freertos-webrtc-reference-on-amebapro-for-amazon-kinesis-video-streams/blob/main/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c#L224-L225):
```
if( xSemaphoreTake( pSrtpSender->senderMutex,
    portMAX_DELAY ) == pdTRUE )
```

*Description of changes:*
This PR improves the WebRTC implementation by optimizing the SRTP sender lock handling and adding initialization flags to buffer structures. The changes include:
- Reuse SRTP sender mutex instead of creating and deleting it for each session
- Add initialization flags to rolling buffer and jitter buffer structures
- Add proper initialization checks throughout buffer operations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
