### PR TITLE
Centralize NAT traversal configuration in AppContext

### DIFF
--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -180,7 +180,7 @@ static int32_t StartPeerConnectionSession( AppContext_t * pAppContext,
         #endif /* #if defined( AWS_CA_CERT_PEM ) */
 
         pcConfig.canTrickleIce = 1U;
-        pcConfig.natTraversalConfigBitmap = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
+        pcConfig.natTraversalConfigBitmap = pAppContext->natTraversalConfig;
 
         ret = GetIceServerList( pAppContext,
                                 pcConfig.iceServers,
@@ -686,8 +686,7 @@ static int32_t InitializeAppSession( AppContext_t * pAppContext,
 
     memset( &pcConfig, 0, sizeof( PeerConnectionSessionConfiguration_t ) );
     pcConfig.canTrickleIce = 1U;
-    pcConfig.natTraversalConfigBitmap = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
-
+    pcConfig.natTraversalConfigBitmap = pAppContext->natTraversalConfig;
     peerConnectionResult = PeerConnection_Init( &pAppSession->peerConnectionSession,
                                                 &pcConfig );
     if( peerConnectionResult != PEER_CONNECTION_RESULT_OK )
@@ -1318,6 +1317,7 @@ int AppCommon_Init( AppContext_t * pAppContext, InitTransceiverFunc_t initTransc
             Sctp_Init();
         #endif /* ENABLE_SCTP_DATA_CHANNEL */
 
+        pAppContext->natTraversalConfig = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
         pAppContext->initTransceiverFunc = initTransceiverFunc;
         pAppContext->pAppMediaSourcesContext = pMediaContext;
     }

--- a/examples/app_common/app_common.h
+++ b/examples/app_common/app_common.h
@@ -66,6 +66,8 @@ typedef struct AppContext
     /* Media context. */
     InitTransceiverFunc_t initTransceiverFunc;
     AppMediaSourcesContext_t * pAppMediaSourcesContext;
+
+    IceControllerNatTraversalConfig_t natTraversalConfig;
 } AppContext_t;
 
 int AppCommon_Init( AppContext_t * pAppContext, InitTransceiverFunc_t initTransceiverFunc, void * pMediaContext );


### PR DESCRIPTION
*Description of changes:*
Refactor NAT traversal configuration management to eliminate duplicate configuration and improve maintainability.


Changes:
- Added` natTraversalConfig` field to `AppContext_t` structure to store the NAT traversal configuration
- Initialized natTraversalConfig in` AppCommon_Init` with `ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL`
- Modified `InitializeAppSession` and `StartPeerConnectionSession` to use the centralized configuration from AppContext
- Removed duplicate NAT traversal configuration assignments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
