### PR TITLE
Solve fetch credential issue in some regions

### DIFF
--- a/examples/networking/networking.c
+++ b/examples/networking/networking.c
@@ -1080,6 +1080,14 @@ static int LwsHttpCallback( struct lws * pWsi,
                 LogError( ( "lws_http_client_read failed!" ) );
                 ret = -1;
             }
+            else
+            {
+                LogDebug( ( "Complete reading, close the connection." ) );
+
+                lws_set_timeout( pWsi,
+                                 PENDING_TIMEOUT_USER_OK,
+                                 LWS_TO_KILL_ASYNC );
+            }
         }
         break;
 
@@ -1185,6 +1193,9 @@ static int LwsHttpCallback( struct lws * pWsi,
             LogDebug( ( "LWS_CALLBACK_WSI_DESTROY callback." ) );
 
             pHttpContext->connectionClosed = 1;
+
+            /* abort poll wait */
+            lws_cancel_service( pHttpContext->pLwsContext );
         }
         break;
 

--- a/examples/signaling_controller/signaling_controller.c
+++ b/examples/signaling_controller/signaling_controller.c
@@ -984,6 +984,7 @@ static void LogSignalingInfo( SignalingControllerContext_t * pCtx )
             LogInfo( ( "        URI: %s", &( pCtx->iceServerConfigs[ i ].iceServerUris[ j ].uri[ 0 ] ) ) );
         }
     }
+    fflush( stdout );
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
*Issue #, if available:*
While using IoT credential to fetch AWS credential, it's possible to take ~10 seconds to complete.

*Description of changes:*
libwebsocket doesn't close the connection in time even we have completed all read operations from the server while using HTTP GET method. In this PR, it invokes `lws_set_timeout` after read operation to force lws to close HTTP connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
