### PR TITLE
Create and destroy HTTP LWS context for every request.

### DIFF
--- a/examples/networking/networking.c
+++ b/examples/networking/networking.c
@@ -38,7 +38,7 @@
 
 #if NETWORKING_USE_MBEDTLS
     /**
-     *  @brief mbedTLS Hash Context passed to SigV4 cryptointerface for generating the hash digest.
+     *  @brief mbedTLS Hash Context passed to SigV4 crypto interface for generating the hash digest.
      */
     static mbedtls_sha256_context xHashContext = { 0 };
 #endif /* NETWORKING_USE_MBEDTLS */
@@ -114,7 +114,7 @@ static int LwsWebsocketCallback( struct lws * pWsi,
 
 /*----------------------------------------------------------------------------*/
 
-#elif NETWORKING_USE_MBEDTLS /* if NETWORKING_USE_OPENSSL  */
+#elif NETWORKING_USE_MBEDTLS /* if NETWORKING_USE_OPENSSL */
     static int32_t Sha256Init( void * hashContext )
     {
         mbedtls_sha256_init( ( mbedtls_sha256_context * ) hashContext );
@@ -1191,7 +1191,7 @@ static int LwsHttpCallback( struct lws * pWsi,
 
             pHttpContext->connectionClosed = 1;
 
-            /* abort poll wait */
+            /* Abort poll wait. */
             lws_cancel_service( pHttpContext->pLwsContext );
         }
         break;
@@ -1435,8 +1435,8 @@ static NetworkingResult_t ConfigureLwsLogging( uint32_t logLevel )
 {
     NetworkingResult_t ret = NETWORKING_RESULT_OK;
     int lws_levels = 0;
-  
-    /* Map application log levels to libwebsockets log levels */
+
+    /* Map application log levels to libwebsockets log levels. */
     if( logLevel == LOG_NONE )
     {
         lws_levels = 0;
@@ -1467,7 +1467,7 @@ static NetworkingResult_t ConfigureLwsLogging( uint32_t logLevel )
         lws_levels |= LLL_DEBUG;
     }
 
-    /* Configure libwebsockets with the mapped log levels */
+    /* Configure libwebsockets with the mapped log levels. */
     lws_set_log_level( lws_levels, NULL );
 
     return ret;
@@ -1518,6 +1518,8 @@ static NetworkingResult_t CreateHttpLwsContext( NetworkingHttpContext_t * pHttpC
     return ret;
 }
 
+/*----------------------------------------------------------------------------*/
+
 NetworkingResult_t Networking_HttpInit( NetworkingHttpContext_t * pHttpCtx,
                                         const SSLCredentials_t * pCreds )
 {
@@ -1538,11 +1540,12 @@ NetworkingResult_t Networking_HttpInit( NetworkingHttpContext_t * pHttpCtx,
         pHttpCtx->protocols[ 1 ].callback = NULL; /* End marker. */
 
         memset( &( pHttpCtx->sslCreds ), 0, sizeof( SSLCredentials_t ) );
+
         pHttpCtx->sslCreds.pCaCertPath = pCreds->pCaCertPath;
         pHttpCtx->sslCreds.pDeviceCertPath = pCreds->pDeviceCertPath;
         pHttpCtx->sslCreds.pDeviceKeyPath = pCreds->pDeviceKeyPath;
 
-        /* Configure libwebsockets logging based on application log level */
+        /* Configure libwebsockets logging based on application log level. */
         ConfigureLwsLogging( LIBRARY_LOG_LEVEL );
     }
 
@@ -1740,7 +1743,7 @@ NetworkingResult_t Networking_HttpSend( NetworkingHttpContext_t * pHttpCtx,
         /* Needed to receive the response in the user supplied buffer. */
         pHttpCtx->pResponse = pResponse;
 
-        /* HTTP status code (200, 403, etc) would be stored in this varirable. */
+        /* HTTP status code (200, 403, etc) would be stored in this variable. */
         pHttpCtx->httpStatusCode = 0;
 
         memset( &( connectInfo ), 0, sizeof( struct lws_client_connect_info ) );
@@ -1813,7 +1816,7 @@ NetworkingResult_t Networking_WebsocketConnect( NetworkingWebsocketContext_t * p
             memset( &retryPolicy, 0, sizeof( lws_retry_bo_t ) );
             retryPolicy.secs_since_valid_ping = 10;
             retryPolicy.secs_since_valid_hangup = 7200;
-        
+
             memset( &creationInfo, 0, sizeof( struct lws_context_creation_info ) );
             creationInfo.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
             creationInfo.port = CONTEXT_PORT_NO_LISTEN;
@@ -1829,14 +1832,14 @@ NetworkingResult_t Networking_WebsocketConnect( NetworkingWebsocketContext_t * p
             creationInfo.retry_and_idle_policy = &retryPolicy;
             creationInfo.fd_limit_per_thread = 3;
             creationInfo.alpn = "http/1.1";
-        
+
             if( ( pWebsocketCtx->sslCreds.pDeviceCertPath != NULL ) && ( pWebsocketCtx->sslCreds.pDeviceKeyPath != NULL ) )
             {
                 creationInfo.client_ssl_cert_filepath = pWebsocketCtx->sslCreds.pDeviceCertPath;
                 creationInfo.client_ssl_private_key_filepath = pWebsocketCtx->sslCreds.pDeviceKeyPath;
             }
 
-            /* Configure libwebsockets logging based on application log level */
+            /* Configure libwebsockets logging based on application log level. */
             ConfigureLwsLogging( LIBRARY_LOG_LEVEL );
 
             pWebsocketCtx->pLwsContext = lws_create_context( &creationInfo );

--- a/examples/networking/networking.h
+++ b/examples/networking/networking.h
@@ -134,6 +134,7 @@ typedef struct NetworkingHttpContext
 {
     struct lws_context * pLwsContext;
     struct lws_protocols protocols[ 2 ];
+    SSLCredentials_t sslCreds;
 
     /* Current time in ISO8601 format. */
     char iso8601Time[ ISO8601_TIME_LENGTH ];


### PR DESCRIPTION
*Issue #, if available:*
It's possible to receive partial data from `lws_http_client_read`. Thus we shouldn't close the connection there.

*Description of changes:*
Destroy the lws context manually and re-create one when needed for every HTTP request. Close the connection whenever getting callback reason `LWS_CALLBACK_COMPLETED_CLIENT_HTTP`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
